### PR TITLE
obs-output: Set ffmpeg audio name

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1609,12 +1609,14 @@ inline void AdvancedOutput::SetupFFmpeg()
 
 		OBSDataAutoRelease item = obs_data_create();
 		obs_data_set_string(item, "name", audioName);
-		obs_data_array_push_back(audio_names, item);	
+		obs_data_array_push_back(audio_names, item);
 	}
 
 	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_array(settings, "audio_names", audio_names);
+	obs_data_array_release(audio_names);
+
 	obs_data_set_string(settings, "url", url);
 	obs_data_set_string(settings, "format_name", formatName);
 	obs_data_set_string(settings, "format_mime_type", mimeType);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1597,27 +1597,24 @@ inline void AdvancedOutput::SetupFFmpeg()
 	const char *aEncCustom =
 		config_get_string(main->Config(), "AdvOut", "FFACustom");
 	
-	OBSDataAutoRelease settings = obs_data_create();
-	//obs_data_array_t *array = obs_data_array_create();
+	obs_data_array_t *audio_names = obs_data_array_create();
 
-    for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
-	    string cfg_name = "Track";
-	    cfg_name += to_string((int)i + 1);
-	    cfg_name += "Name";
-	    const char *name = config_get_string(main->Config(), "AdvOut",
-					         cfg_name.c_str());
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+		string cfg_name = "Track";
+		cfg_name += to_string((int)i + 1);
+		cfg_name += "Name";
 
-	    string def_name = "Track";
-	    def_name += to_string((int)i + 1);
-	    // // SetEncoderName(aacTrack[i], name, def_name.c_str());
-		// (name && *name) ? name : defaultName
-		//obs_data_set_string(audioNames, def_name, name);
-    
-		//obs_data_array_push_back(array, name);
-	
-		obs_data_set_string(settings, def_name.c_str(), name);
+		const char *audioName = config_get_string(main->Config(), "AdvOut",
+								cfg_name.c_str());
+
+		OBSDataAutoRelease item = obs_data_create();
+		obs_data_set_string(item, "name", audioName);
+		obs_data_array_push_back(audio_names, item);	
 	}
 
+	OBSDataAutoRelease settings = obs_data_create();
+
+	obs_data_set_array(settings, "audio_names", audio_names);
 	obs_data_set_string(settings, "url", url);
 	obs_data_set_string(settings, "format_name", formatName);
 	obs_data_set_string(settings, "format_mime_type", mimeType);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1596,7 +1596,27 @@ inline void AdvancedOutput::SetupFFmpeg()
 		config_get_int(main->Config(), "AdvOut", "FFAEncoderId");
 	const char *aEncCustom =
 		config_get_string(main->Config(), "AdvOut", "FFACustom");
+	
 	OBSDataAutoRelease settings = obs_data_create();
+	//obs_data_array_t *array = obs_data_array_create();
+
+    for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+	    string cfg_name = "Track";
+	    cfg_name += to_string((int)i + 1);
+	    cfg_name += "Name";
+	    const char *name = config_get_string(main->Config(), "AdvOut",
+					         cfg_name.c_str());
+
+	    string def_name = "Track";
+	    def_name += to_string((int)i + 1);
+	    // // SetEncoderName(aacTrack[i], name, def_name.c_str());
+		// (name && *name) ? name : defaultName
+		//obs_data_set_string(audioNames, def_name, name);
+    
+		//obs_data_array_push_back(array, name);
+	
+		obs_data_set_string(settings, def_name.c_str(), name);
+	}
 
 	obs_data_set_string(settings, "url", url);
 	obs_data_set_string(settings, "format_name", formatName);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -403,6 +403,12 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
 	data->audio_infos[idx].stream = stream;
 	data->audio_infos[idx].ctx = context;
 
+	
+	//char _title[100];
+	//sprintf_s(_title, sizeof(_title), "n%d", stream->id);
+	if(data->config.audio_track_names[idx] && *data->config.audio_track_names[idx] != '\0')
+		av_dict_set(&stream->metadata, "title", data->config.audio_track_names[idx], 0);
+
 	return open_audio_codec(data, idx);
 }
 
@@ -1190,6 +1196,12 @@ static bool try_connect(struct ffmpeg_output *output)
 		config.scale_width = config.width;
 	if (!config.scale_height)
 		config.scale_height = config.height;
+
+    for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+		char name[100];
+		sprintf_s(name, sizeof(name), "Track%i", (int)(i + 1));
+		config.audio_track_names[i] = obs_data_get_string(settings, name);
+    }
 
 	success = ffmpeg_data_init(&output->ff_data, &config);
 	obs_data_release(settings);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -40,6 +40,7 @@ struct ffmpeg_cfg {
 	const char *username;
 	const char *password;
 	const char *key;
+	const char *audio_track_names[MAX_AUDIO_MIXES];
 };
 
 struct ffmpeg_audio_info {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -40,7 +40,7 @@ struct ffmpeg_cfg {
 	const char *username;
 	const char *password;
 	const char *key;
-	const char *audio_track_names[MAX_AUDIO_MIXES];
+	const char *audio_tracks_names[MAX_AUDIO_MIXES];
 };
 
 struct ffmpeg_audio_info {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -40,7 +40,7 @@ struct ffmpeg_cfg {
 	const char *username;
 	const char *password;
 	const char *key;
-	const char *audio_tracks_names[MAX_AUDIO_MIXES];
+	const char *audio_stream_names[MAX_AUDIO_MIXES];
 };
 
 struct ffmpeg_audio_info {


### PR DESCRIPTION
1. get name
in `window-basic-main-outputs.cpp`
    ```c++
	    for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
		    string cfg_name = "Track";
		    cfg_name += to_string((int)i + 1);
		    cfg_name += "Name";
		    const char *name = config_get_string(main->Config(), "AdvOut",
						         cfg_name.c_str());
    
		    string def_name = "Track";
		    def_name += to_string((int)i + 1);
		    SetEncoderName(aacTrack[i], name, def_name.c_str());
	    }
    ```
2. set name
in [plugins/obs-ffmpeg/obs-ffmpeg-output.c](https://github.com/tuduweb/obs-studio/commit/a05d7946abffae6e41b44b2e666c537045ce5f65#diff-494928bd63dbef2d1f5dd72786864775b9b4383a0aa5db3548484dc3d12fd0f5)

    ```c
    
	    char _title[100];
	    sprintf_s(_title, sizeof(_title), "n%d", stream->id);
	    av_dict_set(&stream->metadata, "title", _title, 0);
    ```

`StartRecording` -> `UpdateRecordingSettings` -> `UpdateAudioSettings`

Modified in:
`inline void AdvancedOutput::SetupFFmpeg()`