### PR TITLE
libobs/media-io: Specify codec tag when it is compatible in out stream

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -153,17 +153,21 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 		av_dict_copy(&out_stream->metadata, in_stream->metadata, 0);
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-		if (in_stream->codecpar->codec_id == AV_CODEC_ID_HEVC &&
-		    job->ofmt_ctx->oformat->codec_tag &&
+		if(!job->ofmt_ctx->oformat->codec_tag) {
+			out_stream->codecpar->codec_tag = 0;
+		}else if(in_stream->codecpar->codec_id == AV_CODEC_ID_HEVC &&
 		    av_codec_get_id(job->ofmt_ctx->oformat->codec_tag,
-				    MKTAG('h', 'v', 'c', '1')) ==
-			    out_stream->codecpar->codec_id) {
+				    MKTAG('h', 'v', 'c', '1')) {
 			// Tag HEVC files with industry standard HVC1 tag for wider device compatibility
 			// when HVC1 tag is supported by out stream codec
 			out_stream->codecpar->codec_tag =
 				MKTAG('h', 'v', 'c', '1');
-		} else {
-			// Otherwise tag 0 to let FFmpeg automatically select the appropriate tag
+		}else if(av_codec_get_id(job->ofmt_ctx->oformat->codec_tag,
+				    in_stream->codecpar->codec_tag) ==
+			    out_stream->codecpar->codec_id) {
+			// Specify codec_tag when the tag is valid in out stream codec
+			out_stream->codecpar->codec_tag = in_stream->codecpar->codec_tag;
+		}else{
 			out_stream->codecpar->codec_tag = 0;
 		}
 #else


### PR DESCRIPTION
Specify codec tag when it is compatible in out stream

https://github.com/obsproject/obs-studio/pull/8055

Or solution 2:
Check and Select outstream tag as possible in OBS remux.

1. Specify HVC in HEVC codec if possible
2. Specify out stream codec tag as in stream tag if avaliable in codec_tags